### PR TITLE
python3 + numpy / jupyter notebook environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ Type `jupyter notebook` in terminal in the main directory and the code will appe
 ## Credits
 
 Credits go to [Trask](http://iamtrask.github.io/2015/07/12/basic-python-network/) and [Litery](https://github.com/Litery). I've merely created a wrapper to get people started. 
+
+## Python 2/3 Troubleshooting 
+
+## Conda
+Install Conda https://conda.io/docs/installation.html
+
+//OSX / Linux Windows
+conda create -n maths python=3.5
+source activate maths
+conda install pandas matplotlib jupyter notebook scipy scikit-learn nb_conda  
+
+


### PR DESCRIPTION
https://gist.github.com/johndpope/187b0dd996d16152ace2f842d43e3990

do try this out. it simplifies having to use virtual environment and creating bin folder.

It may suit to have a link to a gist instead of adding to every readme file.



Having used pip before - i don't recommend it
why? 
because right off the bat - 
pip maybe linked to pip2 or pip3
python by default is linked to python2 on mac.
so pip is linked to python 2.

if you use pip3 it will successfully install python3 dependencies - but you still need to activate environment or write 
**python3** source_file_name.py

all that trouble gets taken care of with conda / environments which are transparent to virtual environments but it centralizes it.
it's better than docker that I suggested some time back 
https://github.com/llSourcell/AI_Composer/issues/8



